### PR TITLE
feat: explore page quiz list 변경사항 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-error-boundary": "^5.0.0",
     "react-fast-marquee": "^1.6.5",
     "react-hook-form": "^7.54.2",
+    "react-intersection-observer": "^9.16.0",
     "react-lottie-player": "^2.1.0",
     "react-router": "^7.2.0",
     "recharts": "^2.15.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.2
         version: 7.55.0(react@19.1.0)
+      react-intersection-observer:
+        specifier: ^9.16.0
+        version: 9.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-lottie-player:
         specifier: ^2.1.0
         version: 2.1.0(react@19.1.0)
@@ -5147,6 +5150,15 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-intersection-observer@9.16.0:
+    resolution: {integrity: sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -11504,6 +11516,12 @@ snapshots:
   react-hook-form@7.55.0(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  react-intersection-observer@9.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
 
   react-is@16.13.1: {}
 

--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -49,6 +49,7 @@
   --color-yellow: #ffe45f;
 
   --shadow-md: 0 4px 28px 0 rgba(0, 0, 0, 0.1);
+  --shadow-drop: 0 4px 20px 0 rgba(0, 0, 0, 0.2);
 
   --header-height: 54px;
 
@@ -195,5 +196,14 @@ body::-webkit-scrollbar {
   100% {
     transform: translateX(0);
     opacity: 1;
+  }
+}
+
+@keyframes skeleton {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
   }
 }

--- a/src/entities/document/api/hooks.ts
+++ b/src/entities/document/api/hooks.ts
@@ -194,27 +194,13 @@ export const useGetBookmarkedDocuments = (options?: { sortOption?: 'CREATED_AT' 
 
 export const useGetPublicDocuments = ({
   categoryId,
-  // page,
   pageSize,
-  // enabled,
 }: {
   categoryId?: number
   page?: number
   pageSize?: number
   enabled?: boolean
 }) => {
-  // return useQuery({
-  //   queryKey: [DOCUMENT_KEYS.getPublicDocuments, categoryId, page],
-  //   queryFn: () => getPublicDocuments({ categoryId, page, pageSize }),
-  //   enabled: enabled ?? true,
-  //   select: (data) => ({
-  //     ...data,
-  //     documents: data.documents.map((doc) => ({
-  //       ...doc,
-  //       quizzes: doc.quizzes.sort((a, b) => b.id - a.id),
-  //     })),
-  //   }),
-  // })
   const query = useInfiniteQuery({
     queryKey: [DOCUMENT_KEYS.getPublicDocuments, categoryId],
     queryFn: ({ pageParam = 0 }) => getPublicDocuments({ categoryId, pageSize, page: pageParam }),
@@ -223,7 +209,6 @@ export const useGetPublicDocuments = ({
       const nextPage = allPages.length
       return nextPage < lastPage.totalPages ? nextPage : undefined
     },
-    // placeholderData: keepPreviousData,
   })
 
   return {

--- a/src/entities/document/api/hooks.ts
+++ b/src/entities/document/api/hooks.ts
@@ -1,4 +1,11 @@
-import { UseQueryOptions, keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  UseQueryOptions,
+  keepPreviousData,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
 
 import { DOCUMENT_KEYS } from './config'
 import {
@@ -187,27 +194,43 @@ export const useGetBookmarkedDocuments = (options?: { sortOption?: 'CREATED_AT' 
 
 export const useGetPublicDocuments = ({
   categoryId,
-  page,
+  // page,
   pageSize,
-  enabled,
+  // enabled,
 }: {
   categoryId?: number
   page?: number
   pageSize?: number
   enabled?: boolean
 }) => {
-  return useQuery({
-    queryKey: [DOCUMENT_KEYS.getPublicDocuments, categoryId, page],
-    queryFn: () => getPublicDocuments({ categoryId, page, pageSize }),
-    enabled: enabled ?? true,
-    select: (data) => ({
-      ...data,
-      documents: data.documents.map((doc) => ({
-        ...doc,
-        quizzes: doc.quizzes.sort((a, b) => b.id - a.id),
-      })),
-    }),
+  // return useQuery({
+  //   queryKey: [DOCUMENT_KEYS.getPublicDocuments, categoryId, page],
+  //   queryFn: () => getPublicDocuments({ categoryId, page, pageSize }),
+  //   enabled: enabled ?? true,
+  //   select: (data) => ({
+  //     ...data,
+  //     documents: data.documents.map((doc) => ({
+  //       ...doc,
+  //       quizzes: doc.quizzes.sort((a, b) => b.id - a.id),
+  //     })),
+  //   }),
+  // })
+  const query = useInfiniteQuery({
+    queryKey: [DOCUMENT_KEYS.getPublicDocuments, categoryId],
+    queryFn: ({ pageParam = 0 }) => getPublicDocuments({ categoryId, pageSize, page: pageParam }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      const nextPage = allPages.length
+      return nextPage < lastPage.totalPages ? nextPage : undefined
+    },
+    // placeholderData: keepPreviousData,
   })
+
+  return {
+    ...query,
+    isInitialFetching: !query.data && query.isFetching,
+    documents: query?.data?.pages?.flatMap((page) => page?.documents ?? []).flat() ?? [],
+  }
 }
 
 export const useGetPublicSingleDocument = (documentId: number, sortOption?: 'CREATED_AT' | 'LOWEST_ACCURACY') => {

--- a/src/features/explore/ui/quiz-list-container/index.tsx
+++ b/src/features/explore/ui/quiz-list-container/index.tsx
@@ -41,29 +41,30 @@ type ShareCard = {
   totalQuizCount: 0
 }
 
-const QuizVerticalSwipe = () => {
+const QuizListContainer = ({ scrollRef }: { scrollRef: React.RefObject<HTMLDivElement | null> }) => {
   const { isPWA } = usePWA()
   const token = useStore(useAuthStore, (state) => state.token)
 
   const DATA_PER_PAGE = 20
 
-  const containerRef = useRef<HTMLDivElement>(null)
+  // const containerRef = useRef<HTMLDivElement>(null)
   const [categoryId] = useQueryParam('/explore', 'category')
 
   const prevCategoryId = useRef(categoryId)
   useEffect(() => {
     if (prevCategoryId.current !== categoryId) {
       // 카테고리 변경 감지 → 스크롤 최상단
-      containerRef.current?.scrollTo(0, 0)
+      scrollRef.current?.scrollTo(0, 0)
       prevCategoryId.current = categoryId
     }
   }, [categoryId])
 
   // 데이터 페칭 관련
-  const { documents, isInitialFetching, hasNextPage, fetchNextPage, isFetchingNextPage } = useGetPublicDocuments({
-    categoryId,
-    pageSize: DATA_PER_PAGE,
-  })
+  const { documents, isFetching, isInitialFetching, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useGetPublicDocuments({
+      categoryId,
+      pageSize: DATA_PER_PAGE,
+    })
 
   const { ref } = useInView({
     onChange: (inView) => {
@@ -96,8 +97,8 @@ const QuizVerticalSwipe = () => {
         height: `calc(100vh - var(--safe-area-inset-top)${accessMobileWeb ? '' : ' - 186px'})`,
         overscrollBehaviorY: 'none',
       }}
-      ref={containerRef}
-      className="relative w-full pt-[8px] flex flex-col items-center overflow-y-auto bg-base-2"
+      // ref={containerRef}
+      className="relative w-full pt-[8px] flex flex-col items-center bg-base-2"
     >
       {documents.reduce<React.ReactNode[]>((acc, document, index) => {
         const isTarget = index === documents.length - 5
@@ -115,7 +116,7 @@ const QuizVerticalSwipe = () => {
             }}
             className="w-full"
           >
-            <ExploreCard containerRef={containerRef} document={document} />
+            <ExploreCard scrollRef={scrollRef} document={document} isFetching={isFetching} />
           </div>,
         )
 
@@ -139,11 +140,13 @@ const QuizVerticalSwipe = () => {
 
 // 공개 문서 카드
 const ExploreCard = ({
-  containerRef,
+  scrollRef,
   document,
+  isFetching,
 }: {
-  containerRef: React.RefObject<HTMLDivElement | null>
+  scrollRef: React.RefObject<HTMLDivElement | null>
   document: GetPublicDocumentsDto
+  isFetching: boolean
 }) => {
   const token = useStore(useAuthStore, (state) => state.token)
 
@@ -259,7 +262,7 @@ const ExploreCard = ({
   const handleClickMoveToDetailPageBtn = () => {
     trackEvent('explore_detail_click')
 
-    const container = containerRef.current
+    const container = scrollRef.current
     if (container) {
       sessionStorage.setItem('scrollY', String(container.scrollTop))
     }
@@ -268,7 +271,7 @@ const ExploreCard = ({
   }
 
   useEffect(() => {
-    const container = containerRef.current
+    const container = scrollRef.current
     const savedScrollY = sessionStorage.getItem('scrollY')
     if (container && savedScrollY) {
       container.scrollTo(0, parseInt(savedScrollY))
@@ -281,7 +284,11 @@ const ExploreCard = ({
       <ExploreQuizCard>
         <ExploreQuizCard.Content>
           <ExploreQuizCard.Header emoji={emoji} title={name} creator={creator} />
-          <ExploreQuizCard.Quizzes onClickMoveToDetailPageBtn={handleClickMoveToDetailPageBtn} quizzes={quizzes} />
+          <ExploreQuizCard.Quizzes
+            onClickMoveToDetailPageBtn={handleClickMoveToDetailPageBtn}
+            quizzes={quizzes}
+            isFetching={isFetching}
+          />
         </ExploreQuizCard.Content>
         <ExploreQuizCard.Footer
           totalQuizCount={quizzes.length}
@@ -333,4 +340,4 @@ const ShareCard = ({ notPublicCount }: { notPublicCount: number }) => {
   )
 }
 
-export default QuizVerticalSwipe
+export default QuizListContainer

--- a/src/pages/explore/explore-page.tsx
+++ b/src/pages/explore/explore-page.tsx
@@ -129,7 +129,7 @@ const ExplorePage = () => {
         <LoginDialog open={isLoginOpen} onOpenChange={setIsLoginOpen} />
 
         {/* 새로운 퀴즈 만들기 버튼 */}
-        <CreateQuizButton />
+        {!hideHeader && <CreateQuizButton />}
       </HeaderOffsetLayout>
     </>
   )

--- a/src/pages/explore/explore-page.tsx
+++ b/src/pages/explore/explore-page.tsx
@@ -57,7 +57,7 @@ const ExplorePage = () => {
   }
 
   useEffect(() => {
-    let prevScrollY = listScrollRef.current?.scrollTop ?? 0 // 클로저 변수
+    let prevScrollY = listScrollRef.current?.scrollTop ?? 0
 
     const handleScroll = () => {
       const currentY = listScrollRef.current?.scrollTop ?? 0
@@ -66,7 +66,7 @@ const ExplorePage = () => {
       } else {
         setHideHeader(false)
       }
-      prevScrollY = currentY // 클로저 값 업데이트
+      prevScrollY = currentY
     }
 
     listScrollRef.current?.addEventListener('scroll', handleScroll)
@@ -122,7 +122,7 @@ const ExplorePage = () => {
         {/* 카테고리 선택 탭 */}
         <CategoryTab />
 
-        {/* 카드 스와이프 영역 */}
+        {/* 퀴즈 리스트 영역 */}
         <QuizListContainer scrollRef={listScrollRef} />
 
         {/* 로그인 모달 */}
@@ -141,6 +141,7 @@ export default withHOC(ExplorePage, {
   backgroundClassName: 'bg-surface-2 h-fit',
 })
 
+// 카테고리 선택 탭 컴포넌트
 const CategoryTab = () => {
   const { trackEvent } = useAmplitude()
 
@@ -207,6 +208,7 @@ const CategoryTab = () => {
   )
 }
 
+// 새로운 퀴즈 만들기 버튼 컴포넌트
 const CreateQuizButton = () => {
   const { trackEvent } = useAmplitude()
 
@@ -251,6 +253,7 @@ const CreateQuizButton = () => {
   )
 }
 
+// 앱 다운로드 배너 컴포넌트
 const AppDownloadBanner = ({ onClick, onClose }: { onClick: () => void; onClose: () => void }) => {
   return (
     <div
@@ -306,6 +309,7 @@ const AppDownloadBanner = ({ onClick, onClose }: { onClick: () => void; onClose:
   )
 }
 
+// pc 화면에서 다운로드 배너 클릭 시 노출될 QR코드 drawer 컴포넌트
 const DesktopDownloadQRDrawer = ({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) => {
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>

--- a/src/pages/explore/explore-page.tsx
+++ b/src/pages/explore/explore-page.tsx
@@ -8,11 +8,11 @@ import HeaderOffsetLayout from '@/app/layout/header-offset-layout'
 
 import { useAuthStore } from '@/features/auth'
 import LoginDialog from '@/features/explore/ui/login-dialog'
-import QuizVerticalSwipe from '@/features/explore/ui/quiz-vertical-swipe'
+import QuizListContainer from '@/features/explore/ui/quiz-list-container'
 
 import { useGetCategories } from '@/entities/category/api/hooks'
 
-import { IcClose, IcLogo, IcProfile, IcSearch } from '@/shared/assets/icon'
+import { IcClose, IcFile, IcLogo, IcProfile, IcSearch } from '@/shared/assets/icon'
 import { Header } from '@/shared/components/header'
 import { Chip } from '@/shared/components/ui/chip'
 import { Drawer, DrawerContent, DrawerHeader } from '@/shared/components/ui/drawer'
@@ -26,22 +26,15 @@ import { cn } from '@/shared/lib/utils'
 const ExplorePage = () => {
   const token = useStore(useAuthStore, (state) => state.token)
 
-  const { trackEvent } = useAmplitude()
   const router = useRouter()
   const { isPWA } = usePWA()
+
+  const listScrollRef = useRef<HTMLDivElement>(null)
+  const [hideHeader, setHideHeader] = useState(false)
 
   const [isLoginOpen, setIsLoginOpen] = useState(false)
   const [isAppDownloadBannerOpen, setIsAppDownloadBannerOpen] = useState(!isPWA && isMobile)
   const [isAppDownloadDrawerOpen, setIsAppDownloadDrawerOpen] = useState(false)
-
-  const { data: categoryData, isLoading } = useGetCategories()
-
-  const [params, setParams] = useQueryParam('/explore')
-  const activeCategory = params.category
-
-  const setCategory = (categoryId: number) => {
-    setParams({ ...params, category: categoryId })
-  }
 
   const scrollRef = useRef<HTMLDivElement>(null)
   useHorizontalScrollWheel(scrollRef)
@@ -64,6 +57,23 @@ const ExplorePage = () => {
   }
 
   useEffect(() => {
+    let prevScrollY = listScrollRef.current?.scrollTop ?? 0 // 클로저 변수
+
+    const handleScroll = () => {
+      const currentY = listScrollRef.current?.scrollTop ?? 0
+      if (currentY > prevScrollY && currentY > 0) {
+        setHideHeader(true)
+      } else {
+        setHideHeader(false)
+      }
+      prevScrollY = currentY // 클로저 값 업데이트
+    }
+
+    listScrollRef.current?.addEventListener('scroll', handleScroll)
+    return () => listScrollRef.current?.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  useEffect(() => {
     if ((!isPWA && isMobile) || !isMobile) {
       // PWA가 아니고 모바일인 경우, 또는 pc 접근일 경우, 앱 다운로드 배너를 열도록 설정
       setIsAppDownloadBannerOpen(true)
@@ -74,120 +84,52 @@ const ExplorePage = () => {
 
   return (
     <>
-      <Header
-        className={cn('bg-surface-2')}
-        left={
-          <button onClick={handleProfileClick} className="size-[40px] flex-center">
-            <IcProfile className="size-[24px]" />
-          </button>
-        }
-        right={
-          <Link to={'/explore/search'} className="size-[40px] flex-center">
-            <IcSearch className="size-[24px]" />
-          </Link>
-        }
-        content={
-          <div className="center">
-            <IcLogo className="w-[102px] h-[26px]" />
-          </div>
-        }
-      />
+      {!hideHeader && (
+        <Header
+          className={cn('bg-surface-2')}
+          left={
+            <button onClick={handleProfileClick} className="size-[40px] flex-center">
+              <IcProfile className="size-[24px]" />
+            </button>
+          }
+          right={
+            <Link to={'/explore/search'} className="size-[40px] flex-center">
+              <IcSearch className="size-[24px]" />
+            </Link>
+          }
+          content={
+            <div className="center">
+              <IcLogo className="w-[102px] h-[26px]" />
+            </div>
+          }
+        />
+      )}
 
-      <HeaderOffsetLayout className="overscroll-none">
+      <HeaderOffsetLayout
+        ref={listScrollRef}
+        className={cn(
+          'overscroll-none h-full overflow-y-auto scrollbar-hide',
+          hideHeader && 'pt-0 h-[calc(100vh-var(--spacing-tab-navigation))]',
+        )}
+      >
         {/* 앱 다운로드 배너 */}
         {isAppDownloadBannerOpen && (
           <AppDownloadBanner onClick={handleAppDownloadBannerClick} onClose={() => setIsAppDownloadBannerOpen(false)} />
         )}
         {/* pc 화면에서 다운로드 배너 클릭 시 노출될 QR코드 drawer */}
-        <Drawer open={isAppDownloadDrawerOpen} onOpenChange={setIsAppDownloadDrawerOpen}>
-          <DrawerContent height="lg" hasHandle={false}>
-            <div className="flex justify-end items-center">
-              <button onClick={() => setIsAppDownloadDrawerOpen(false)}>
-                <IcClose className="size-[24px] text-icon-secondary" />
-              </button>
-            </div>
-
-            <DrawerHeader className="flex-center flex-col gap-[8px]">
-              <Text typo="subtitle-1-bold" color="sub" className="text-center">
-                픽토스 앱 다운로드
-              </Text>
-              <Text typo="h3" className="text-center">
-                스토어 방문 없이 3초만에 <br />
-                픽토스에서 매일 성장해보세요!
-              </Text>
-            </DrawerHeader>
-
-            <div className="flex-center pt-[20px] pb-[32px]">
-              <Text typo="subtitle-2-medium" color="accent">
-                * 휴대폰으로 QR코드를 촬영해주세요
-              </Text>
-            </div>
-
-            <div className="relative size-[250px] w-full flex-center">
-              <div className="absolute">
-                <FocusBox />
-              </div>
-
-              <img
-                src="/images/QR_picktoss_app_install.png"
-                alt="픽토스 앱 다운로드 QR코드"
-                className="w-[208px] h-[208px]"
-              />
-            </div>
-          </DrawerContent>
-        </Drawer>
+        <DesktopDownloadQRDrawer open={isAppDownloadDrawerOpen} onOpenChange={setIsAppDownloadDrawerOpen} />
 
         {/* 카테고리 선택 탭 */}
-        <div ref={scrollRef} className=" bg-base-2 flex gap-[6px] overflow-x-auto scrollbar-hide px-[8px] py-[8px]">
-          {isLoading ? (
-            Array.from({ length: 7 }).map((_, index) => (
-              <div key={'tab-skeleton-' + index} className="h-[30px] w-[82px] rounded-full bg-base-3 animate-pulse" />
-            ))
-          ) : (
-            <>
-              {/* 전체 */}
-              <Chip
-                variant={activeCategory === 0 ? 'selected' : 'darken'}
-                left={activeCategory === 0 ? '💫' : undefined}
-                onClick={() => setCategory(0)}
-                className={cn('ml-[16px]')}
-              >
-                전체
-              </Chip>
-
-              {/* Chip 요소들 */}
-              {categoryData &&
-                categoryData.map((category, index) => (
-                  <Chip
-                    key={index}
-                    variant={category.id === activeCategory ? 'selected' : 'darken'}
-                    left={category.id === activeCategory ? category.emoji : undefined}
-                    onClick={() => {
-                      setCategory(category.id)
-                      trackEvent('explore_category_click', {
-                        category: category.name as
-                          | '전체'
-                          | '자격증·수험'
-                          | '학문·전공'
-                          | 'IT·개발'
-                          | '재테크·시사'
-                          | '언어'
-                          | '상식·교양',
-                      })
-                    }}
-                  >
-                    {category.name}
-                  </Chip>
-                ))}
-            </>
-          )}
-        </div>
+        <CategoryTab />
 
         {/* 카드 스와이프 영역 */}
-        <QuizVerticalSwipe />
+        <QuizListContainer scrollRef={listScrollRef} />
 
         {/* 로그인 모달 */}
         <LoginDialog open={isLoginOpen} onOpenChange={setIsLoginOpen} />
+
+        {/* 새로운 퀴즈 만들기 버튼 */}
+        <CreateQuizButton />
       </HeaderOffsetLayout>
     </>
   )
@@ -198,6 +140,116 @@ export default withHOC(ExplorePage, {
   navClassName: 'border-t border-divider z-40',
   backgroundClassName: 'bg-surface-2 h-fit',
 })
+
+const CategoryTab = () => {
+  const { trackEvent } = useAmplitude()
+
+  const { data: categoryData, isLoading } = useGetCategories()
+
+  const [params, setParams] = useQueryParam('/explore')
+  const activeCategory = params.category
+
+  const setCategory = (categoryId: number) => {
+    setParams({ ...params, category: categoryId })
+  }
+
+  const scrollRef = useRef<HTMLDivElement>(null)
+  useHorizontalScrollWheel(scrollRef)
+
+  return (
+    <div
+      ref={scrollRef}
+      className="sticky top-0 z-10 bg-[linear-gradient(to_bottom,#F8F8F7_25%,rgba(245,245,245,0)_100%)] flex gap-[6px] overflow-x-auto scrollbar-hide px-[8px] py-[8px]"
+    >
+      {isLoading ? (
+        Array.from({ length: 7 }).map((_, index) => (
+          <div key={'tab-skeleton-' + index} className="h-[30px] w-[82px] rounded-full bg-base-3 animate-pulse" />
+        ))
+      ) : (
+        <>
+          {/* 전체 */}
+          <Chip
+            variant={activeCategory === 0 ? 'selected' : 'darken'}
+            left={activeCategory === 0 ? '💫' : undefined}
+            onClick={() => setCategory(0)}
+            className={cn('ml-[16px]')}
+          >
+            전체
+          </Chip>
+
+          {/* Chip 요소들 */}
+          {categoryData &&
+            categoryData.map((category, index) => (
+              <Chip
+                key={index}
+                variant={category.id === activeCategory ? 'selected' : 'darken'}
+                left={category.id === activeCategory ? category.emoji : undefined}
+                onClick={() => {
+                  setCategory(category.id)
+                  trackEvent('explore_category_click', {
+                    category: category.name as
+                      | '전체'
+                      | '자격증·수험'
+                      | '학문·전공'
+                      | 'IT·개발'
+                      | '재테크·시사'
+                      | '언어'
+                      | '상식·교양',
+                  })
+                }}
+              >
+                {category.name}
+              </Chip>
+            ))}
+        </>
+      )}
+    </div>
+  )
+}
+
+const CreateQuizButton = () => {
+  const { trackEvent } = useAmplitude()
+
+  const router = useRouter()
+
+  return (
+    <button
+      className="absolute bg-base-3 rounded-full bottom-[calc(var(--spacing-tab-navigation)+12px)] left-1/2 -translate-x-1/2 h-[48px] w-[calc(100%-32px)] border border-box shadow-[var(--shadow-drop)]"
+      onClick={() => {
+        router.push('/note/create', {
+          search: {
+            documentType: 'TEXT',
+          },
+        })
+        trackEvent('generate_new_click', {
+          format: '텍스트 버튼',
+          location: '데일리 페이지',
+        })
+      }}
+    >
+      <Text typo="subtitle-2-medium" color="sub" className="center">
+        새로운 퀴즈 만들기...
+      </Text>
+      <button
+        onClick={(e) => {
+          e.stopPropagation()
+          router.push('/note/create', {
+            search: {
+              documentType: 'FILE',
+            },
+          })
+          trackEvent('generate_new_click', {
+            format: '파일 버튼',
+            location: '데일리 페이지',
+          })
+        }}
+        className="flex-center bg-orange-500 rounded-full size-10 absolute right-1 bottom-1/2 translate-y-1/2"
+      >
+        <IcFile className="size-5 text-white" />
+      </button>
+    </button>
+  )
+}
 
 const AppDownloadBanner = ({ onClick, onClose }: { onClick: () => void; onClose: () => void }) => {
   return (
@@ -251,6 +303,48 @@ const AppDownloadBanner = ({ onClick, onClose }: { onClick: () => void; onClose:
         <IcClose className="size-[16px]" />
       </button>
     </div>
+  )
+}
+
+const DesktopDownloadQRDrawer = ({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) => {
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent height="lg" hasHandle={false}>
+        <div className="flex justify-end items-center">
+          <button onClick={() => onOpenChange(false)}>
+            <IcClose className="size-[24px] text-icon-secondary" />
+          </button>
+        </div>
+
+        <DrawerHeader className="flex-center flex-col gap-[8px]">
+          <Text typo="subtitle-1-bold" color="sub" className="text-center">
+            픽토스 앱 다운로드
+          </Text>
+          <Text typo="h3" className="text-center">
+            스토어 방문 없이 3초만에 <br />
+            픽토스에서 매일 성장해보세요!
+          </Text>
+        </DrawerHeader>
+
+        <div className="flex-center pt-[20px] pb-[32px]">
+          <Text typo="subtitle-2-medium" color="accent">
+            * 휴대폰으로 QR코드를 촬영해주세요
+          </Text>
+        </div>
+
+        <div className="relative size-[250px] w-full flex-center">
+          <div className="absolute">
+            <FocusBox />
+          </div>
+
+          <img
+            src="/images/QR_picktoss_app_install.png"
+            alt="픽토스 앱 다운로드 QR코드"
+            className="w-[208px] h-[208px]"
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
   )
 }
 

--- a/src/shared/components/cards/explore-quiz-card/index.stories.tsx
+++ b/src/shared/components/cards/explore-quiz-card/index.stories.tsx
@@ -53,32 +53,21 @@ export const Default: StoryObj<typeof ExploreQuizCard> = {
   render: () => {
     return (
       <div className="p-10 flex-center">
-        <ExploreQuizCard
-          index={0}
-          activeIndex={0}
-          header={
-            <ExploreQuizCard.Header
-              creator={'picktoss'}
-              isOwner={false}
-              isBookmarked={false}
-              onClickShare={() => {}}
-              onClickBookmark={() => {}}
-            />
-          }
-          content={
-            <ExploreQuizCard.Content
-              emoji={'🪶'}
-              title={'인지주의 심리학 관련 퀴즈 모음'}
-              category={'IT·개발'}
-              playedCount={345}
-              bookmarkCount={28}
-            />
-          }
-          quizzes={
-            <ExploreQuizCard.Quizzes quizzes={quizzes} totalQuizCount={quizzes.length} onClickViewAllBtn={() => {}} />
-          }
-          footer={<ExploreQuizCard.Footer onClickStartQuiz={() => {}} />}
-        />
+        <ExploreQuizCard>
+          <ExploreQuizCard.Content>
+            <ExploreQuizCard.Header emoji={'🪶'} title={'인지주의 심리학 관련 퀴즈 모음'} creator="picktoss" />
+            <ExploreQuizCard.Quizzes onClickMoveToDetailPageBtn={() => {}} quizzes={quizzes} />
+          </ExploreQuizCard.Content>
+          <ExploreQuizCard.Footer
+            totalQuizCount={25}
+            playedCount={345}
+            bookmarkCount={28}
+            isOwner={false}
+            isBookmarked={false}
+            onClickShare={() => {}}
+            onClickBookmark={() => {}}
+          />
+        </ExploreQuizCard>
       </div>
     )
   },
@@ -86,31 +75,21 @@ export const Default: StoryObj<typeof ExploreQuizCard> = {
     docs: {
       source: {
         code: `
-<ExploreQuizCard
-  index={0}
-  activeIndex={0}
-  header={
-    <ExploreQuizCard.Header
-      owner={'picktoss'}
-      isBookmarked={false}
-      onClickShare={() => {}}
-      onClickBookmark={() => {}}
-    />
-  }
-  content={
-    <ExploreQuizCard.Content
-      emoji={'🪶'}
-      title={'인지주의 심리학 관련 퀴즈 모음'}
-      category={'IT·개발'}
-      playedCount={345}
-      bookmarkCount={28}
-    />
-  }
-  quizzes={
-    <ExploreQuizCard.Quizzes quizzes={quizzes} totalQuizCount={quizzes.length} onClickViewAllBtn={() => {}} />
-  }
-  footer={<ExploreQuizCard.Footer onClickStartQuiz={() => {}} />}
-/>
+        <ExploreQuizCard>
+          <ExploreQuizCard.Content>
+            <ExploreQuizCard.Header emoji={'🪶'} title={'인지주의 심리학 관련 퀴즈 모음'} creator="picktoss" />
+            <ExploreQuizCard.Quizzes onClickMoveToDetailPageBtn={() => {}} quizzes={quizzes} />
+          </ExploreQuizCard.Content>
+          <ExploreQuizCard.Footer
+            totalQuizCount={25}
+            playedCount={345}
+            bookmarkCount={28}
+            isOwner={false}
+            isBookmarked={false}
+            onClickShare={() => {}}
+            onClickBookmark={() => {}}
+          />
+        </ExploreQuizCard>
         `,
       },
     },
@@ -121,32 +100,21 @@ export const Bookmarked: StoryObj<typeof ExploreQuizCard> = {
   render: () => {
     return (
       <div className="p-10 flex-center">
-        <ExploreQuizCard
-          index={0}
-          activeIndex={0}
-          header={
-            <ExploreQuizCard.Header
-              creator={'picktoss'}
-              isOwner={false}
-              isBookmarked={true}
-              onClickShare={() => {}}
-              onClickBookmark={() => {}}
-            />
-          }
-          content={
-            <ExploreQuizCard.Content
-              emoji={'🪶'}
-              title={'인지주의 심리학 관련 퀴즈 모음'}
-              category={'IT·개발'}
-              playedCount={345}
-              bookmarkCount={28}
-            />
-          }
-          quizzes={
-            <ExploreQuizCard.Quizzes quizzes={quizzes} totalQuizCount={quizzes.length} onClickViewAllBtn={() => {}} />
-          }
-          footer={<ExploreQuizCard.Footer onClickStartQuiz={() => {}} />}
-        />
+        <ExploreQuizCard>
+          <ExploreQuizCard.Content>
+            <ExploreQuizCard.Header emoji={'🪶'} title={'인지주의 심리학 관련 퀴즈 모음'} creator="picktoss" />
+            <ExploreQuizCard.Quizzes onClickMoveToDetailPageBtn={() => {}} quizzes={quizzes} />
+          </ExploreQuizCard.Content>
+          <ExploreQuizCard.Footer
+            totalQuizCount={25}
+            playedCount={345}
+            bookmarkCount={28}
+            isOwner={false}
+            isBookmarked={true}
+            onClickShare={() => {}}
+            onClickBookmark={() => {}}
+          />
+        </ExploreQuizCard>
       </div>
     )
   },
@@ -156,32 +124,21 @@ export const Owner: StoryObj<typeof ExploreQuizCard> = {
   render: () => {
     return (
       <div className="p-10 flex-center">
-        <ExploreQuizCard
-          index={0}
-          activeIndex={0}
-          header={
-            <ExploreQuizCard.Header
-              creator={'picktoss'}
-              isOwner={true}
-              isBookmarked={true}
-              onClickShare={() => {}}
-              onClickBookmark={() => {}}
-            />
-          }
-          content={
-            <ExploreQuizCard.Content
-              emoji={'🪶'}
-              title={'인지주의 심리학 관련 퀴즈 모음'}
-              category={'IT·개발'}
-              playedCount={345}
-              bookmarkCount={28}
-            />
-          }
-          quizzes={
-            <ExploreQuizCard.Quizzes quizzes={quizzes} totalQuizCount={quizzes.length} onClickViewAllBtn={() => {}} />
-          }
-          footer={<ExploreQuizCard.Footer onClickStartQuiz={() => {}} />}
-        />
+        <ExploreQuizCard>
+          <ExploreQuizCard.Content>
+            <ExploreQuizCard.Header emoji={'🪶'} title={'인지주의 심리학 관련 퀴즈 모음'} creator="picktoss" />
+            <ExploreQuizCard.Quizzes onClickMoveToDetailPageBtn={() => {}} quizzes={quizzes} />
+          </ExploreQuizCard.Content>
+          <ExploreQuizCard.Footer
+            totalQuizCount={25}
+            playedCount={345}
+            bookmarkCount={28}
+            isOwner={true}
+            isBookmarked={false}
+            onClickShare={() => {}}
+            onClickBookmark={() => {}}
+          />
+        </ExploreQuizCard>
       </div>
     )
   },

--- a/src/shared/components/cards/explore-quiz-card/index.tsx
+++ b/src/shared/components/cards/explore-quiz-card/index.tsx
@@ -54,27 +54,37 @@ const ExploreQuizCardHeader = ({ emoji, title, creator }: { emoji: string; title
 const ExploreQuizCardQuizzes = ({
   onClickMoveToDetailPageBtn,
   quizzes,
+  isFetching,
 }: {
   onClickMoveToDetailPageBtn: () => void
   quizzes: { id: number; question: string }[]
+  isFetching?: boolean
 }) => {
   const showQuizList = quizzes.length > 3 ? quizzes.slice(0, 3) : quizzes
 
   return (
     <div className="flex flex-col gap-[10px] pl-[16px]">
       <div className="flex items-center gap-[8px] overflow-x-auto scrollbar-hide">
-        {showQuizList.map((quiz) => (
-          <div
-            key={`quiz-${quiz.id}`}
-            className={cn(
-              'bg-base-2 py-[12px] px-[16px] w-[280px] h-[64px] rounded-[12px] flex-center flex-shrink-0 border-1 border-outline',
-            )}
-          >
-            <Text typo="body-1-medium" color="sub" className="line-clamp-2">
-              {quiz.question}
-            </Text>
-          </div>
-        ))}
+        {isFetching ? (
+          <>
+            <div className="flex-shrink-0 w-[280px] h-[64px] rounded-[12px]  bg-[linear-gradient(120deg,#f8f8f7_25%,#ffffff_50%,#f8f8f7_75%)] bg-[length:200%_100%] animate-[skeleton_1.8s_linear_infinite]"></div>
+            <div className="flex-shrink-0 w-[280px] h-[64px] rounded-[12px] bg-[linear-gradient(120deg,#f8f8f7_25%,#ffffff_50%,#f8f8f7_75%)] bg-[length:200%_100%] animate-[skeleton_1.8s_linear_infinite]"></div>
+            <div className="flex-shrink-0 w-[280px] h-[64px] rounded-[12px] bg-[linear-gradient(120deg,#f8f8f7_25%,#ffffff_50%,#f8f8f7_75%)] bg-[length:200%_100%] animate-[skeleton_1.8s_linear_infinite]"></div>
+          </>
+        ) : (
+          showQuizList.map((quiz) => (
+            <div
+              key={`quiz-${quiz.id}`}
+              className={cn(
+                'bg-base-2 py-[12px] px-[16px] w-[280px] h-[64px] rounded-[12px] flex-center flex-shrink-0 border-1 border-outline',
+              )}
+            >
+              <Text typo="body-1-medium" color="sub" className="line-clamp-2">
+                {quiz.question}
+              </Text>
+            </div>
+          ))
+        )}
         <ButtonSolidIcon onClick={onClickMoveToDetailPageBtn} size={'md'} variant={'tertiary'} className="mr-[16px]">
           <IcChevronRight className="text-icon-sub" />
         </ButtonSolidIcon>

--- a/src/shared/components/cards/explore-quiz-card/index.tsx
+++ b/src/shared/components/cards/explore-quiz-card/index.tsx
@@ -1,124 +1,50 @@
 import React from 'react'
 
-import { IcBookmark, IcBookmarkFilled, IcMy, IcPlayFilled, IcUpload } from '@/shared/assets/icon'
-import { Button } from '@/shared/components/ui/button'
+import { IcBookmark, IcBookmarkFilled, IcChevronRight, IcPlayFilled, IcUpload } from '@/shared/assets/icon'
 import { ButtonSolidIcon } from '@/shared/components/ui/button-solid-icon'
 import { Text } from '@/shared/components/ui/text'
-import { TextButton } from '@/shared/components/ui/text-button'
 import { cn } from '@/shared/lib/utils'
 
-interface Props {
-  header: React.ReactNode
-  content: React.ReactNode
-  quizzes: React.ReactNode
-  footer: React.ReactNode
-  index?: number
-  activeIndex?: number
-}
-
-export const ExploreQuizCard = ({ index, activeIndex, header, content, quizzes, footer }: Props) => {
+export const ExploreQuizCard = ({
+  children,
+  className,
+  ...props
+}: React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>) => {
   return (
     <div
       className={cn(
-        'w-[343px] h-[500px] relative rounded-[20px] shadow-[0px_4px_28px_0px_rgba(0,0,0,0.10)] overflow-hidden transition-transform duration-300 bg-[linear-gradient(to_bottom,_var(--color-white)_78%,_var(--color-orange-100)_100%)]',
-        activeIndex !== index && 'scale-90 pointer-events-none',
+        'w-full relative bg-surface-1 flex flex-col gap-[16px] pt-[24px] pb-[12px] border-b border-divider',
+        className,
       )}
+      {...props}
     >
-      <div className={cn('size-full flex flex-col justify-between opacity-10', activeIndex === index && 'opacity-100')}>
-        <div className="flex-1/2 flex flex-col gap-[22px]">
-          {header}
-
-          {content}
-        </div>
-
-        <div className="pb-[24px]">
-          {quizzes}
-
-          {footer}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-const ExploreQuizCardHeader = ({
-  creator,
-  isOwner,
-  isBookmarked,
-  onClickShare,
-  onClickBookmark,
-}: {
-  creator: string
-  isOwner: boolean
-  isBookmarked: boolean
-  onClickShare: () => void
-  onClickBookmark: () => void
-}) => {
-  return (
-    <div className="mt-[16px] px-[20px] flex items-center justify-between">
-      <div className="flex gap-[8px]">
-        <div className="size-[20px] flex-center rounded-full bg-base-3">
-          <IcMy className="size-[12px] text-icon-sub" />
-        </div>
-        <Text typo="body-1-medium" color="sub">
-          {creator}
-        </Text>
-      </div>
-      <div className="flex gap-[16px]">
-        <ButtonSolidIcon onClick={onClickShare} variant={'tertiary'} size={'md'}>
-          <IcUpload className="size-[20px]" />
-        </ButtonSolidIcon>
-        {!isOwner && (
-          <ButtonSolidIcon onClick={onClickBookmark} variant={'tertiary'} size={'md'}>
-            {isBookmarked ? (
-              <IcBookmarkFilled className="size-[20px] text-icon-primary" />
-            ) : (
-              <IcBookmark className="size-[20px]" />
-            )}
-          </ButtonSolidIcon>
-        )}
-      </div>
+      {children}
     </div>
   )
 }
 
 const ExploreQuizCardContent = ({
-  emoji,
-  title,
-  category,
-  playedCount,
-  bookmarkCount,
-}: {
-  emoji: string
-  title: string
-  category: string
-  playedCount: number
-  bookmarkCount: number
-}) => {
+  children,
+  className,
+  ...props
+}: React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>) => {
   return (
-    <div className="px-[28px] flex flex-col gap-[4px]">
-      <div className="text-5xl">{emoji}</div>
-      <div className="flex flex-col gap-[12px]">
-        <Text typo="h2" className="line-clamp-2">
+    <div className={cn('flex flex-col gap-[20px]', className)} {...props}>
+      {children}
+    </div>
+  )
+}
+
+const ExploreQuizCardHeader = ({ emoji, title, creator }: { emoji: string; title: string; creator: string }) => {
+  return (
+    <div className="flex items-center gap-[8px] px-[16px]">
+      <div className="w-12 h-12 text-center justify-center text-4xl leading-10">{emoji}</div>
+      <div className="flex flex-col gap-[4px] max-w-64 truncate">
+        <Text typo="h4" className="max-w-64 truncate">
           {title}
         </Text>
-
-        <Text typo="body-1-medium" color="sub" className="flex w-fit items-center">
-          <span>{category}</span>
-
-          <div className="inline-block size-[4px] mx-[8px] bg-[var(--color-gray-100)] rounded-full" />
-
-          <div className="inline-flex justify-start items-center gap-[2px]">
-            <IcPlayFilled className="size-[12px] text-icon-sub" />
-            <span>{playedCount}</span>
-          </div>
-
-          <div className="inline-block size-[4px] mx-[8px] bg-[var(--color-gray-100)] rounded-full" />
-
-          <div className="inline-flex justify-start items-center gap-[2px]">
-            <IcBookmarkFilled className="size-[12px] text-icon-sub" />
-            <span>{bookmarkCount}</span>
-          </div>
+        <Text typo="body-2-medium" color="sub" className="max-w-64 truncate">
+          @{creator}
         </Text>
       </div>
     </div>
@@ -126,63 +52,91 @@ const ExploreQuizCardContent = ({
 }
 
 const ExploreQuizCardQuizzes = ({
-  totalQuizCount,
-  onClickViewAllBtn,
+  onClickMoveToDetailPageBtn,
   quizzes,
 }: {
-  totalQuizCount: number
-  onClickViewAllBtn: () => void
+  onClickMoveToDetailPageBtn: () => void
   quizzes: { id: number; question: string }[]
 }) => {
+  const showQuizList = quizzes.length > 3 ? quizzes.slice(0, 3) : quizzes
+
   return (
-    <div className="flex flex-col gap-[10px]">
-      <div className="px-[28px] flex justify-between">
-        <Text typo="subtitle-2-bold">
-          문제{' '}
-          <Text as={'span'} typo="subtitle-2-bold" color="sub">
-            {totalQuizCount}
-          </Text>
-        </Text>
-
-        <TextButton onClick={onClickViewAllBtn} size={'sm'} variant="sub">
-          전체보기
-        </TextButton>
-      </div>
-
-      <div className="flex gap-[8px] overflow-x-auto scrollbar-hide">
-        {quizzes.map((quiz, index) => (
+    <div className="flex flex-col gap-[10px] pl-[16px]">
+      <div className="flex items-center gap-[8px] overflow-x-auto scrollbar-hide">
+        {showQuizList.map((quiz) => (
           <div
             key={`quiz-${quiz.id}`}
             className={cn(
-              'bg-base-2 py-[9.5px] px-[16px] w-[240px] h-[64px] rounded-[12px] flex-center flex-shrink-0',
-              index === 0 && 'ml-[28px]',
+              'bg-base-2 py-[12px] px-[16px] w-[280px] h-[64px] rounded-[12px] flex-center flex-shrink-0 border-1 border-outline',
             )}
           >
             <Text typo="body-1-medium" color="sub" className="line-clamp-2">
-              <Text as={'span'} typo="body-1-medium" color="accent">
-                Q.{' '}
-              </Text>
               {quiz.question}
             </Text>
           </div>
         ))}
+        <ButtonSolidIcon onClick={onClickMoveToDetailPageBtn} size={'md'} variant={'tertiary'} className="mr-[16px]">
+          <IcChevronRight className="text-icon-sub" />
+        </ButtonSolidIcon>
       </div>
     </div>
   )
 }
 
 const ExploreQuizCardFooter = ({
-  onClickStartQuiz,
-  isLoading,
+  totalQuizCount,
+  playedCount,
+  bookmarkCount,
+  isOwner,
+  isBookmarked,
+  onClickShare,
+  onClickBookmark,
 }: {
-  onClickStartQuiz: () => void
-  isLoading?: boolean
+  totalQuizCount: number
+  playedCount: number
+  bookmarkCount: number
+  isOwner: boolean
+  isBookmarked: boolean
+  onClickShare: () => void
+  onClickBookmark: () => void
 }) => {
   return (
-    <div className="px-[20px] mt-[25px]">
-      <Button onClick={onClickStartQuiz} data-state={isLoading && 'loading'}>
-        퀴즈 시작하기
-      </Button>
+    <div className="px-[8px] flex justify-between items-center">
+      <div className="px-[8px] size-fit">
+        <Text typo="body-2-medium" color="sub" className="flex size-fit items-center">
+          <span>{totalQuizCount}문제</span>
+
+          <div className="inline-block size-[3px] mx-[4px] bg-[var(--color-gray-100)] rounded-full" />
+
+          <div className="inline-flex justify-start items-center gap-[2px]">
+            <IcPlayFilled className="size-[12px] text-icon-sub" />
+            <span>{playedCount}</span>
+          </div>
+
+          <div className="inline-block size-[3px] mx-[4px] bg-[var(--color-gray-100)] rounded-full" />
+
+          <div className="inline-flex justify-start items-center gap-[2px]">
+            <IcBookmarkFilled className="size-[12px] text-icon-sub" />
+            <span>{bookmarkCount}</span>
+          </div>
+        </Text>
+      </div>
+
+      <div className="flex gap-[8px]">
+        <button onClick={onClickShare} className="p-[8px]">
+          <IcUpload className="size-[20px]" />
+        </button>
+
+        {!isOwner && (
+          <button onClick={onClickBookmark} className="p-[8px]">
+            {isBookmarked ? (
+              <IcBookmarkFilled className="size-[20px] text-icon-primary" />
+            ) : (
+              <IcBookmark className="size-[20px]" />
+            )}
+          </button>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Feat
- explore 페이지 스크롤 시
  - 헤더 숨김/노출 기능 추가: 스크롤 방향에 따라 헤더가 자동으로 숨겨지거나 나타나도록 구현
  - 퀴즈 생성 버튼 숨김 기능 구현
- explore quiz card 컴포넌트 구현
- 내부 문제 카드 데이터 페칭 시 스켈레톤 처리 구현

## Refactor
- ExplorePage 구조 개선
  - 카테고리 탭, 퀴즈 리스트, 앱 다운로드 배너, 로그인 다이얼로그, 퀴즈 생성 버튼 등 주요 UI 영역을 별도 컴포넌트로 분리하여 가독성과 유지보수성 향상.
- 컴포넌트 분리
  - 카테고리 탭(CategoryTab) 분리 및 개선
  - 앱 다운로드 배너(AppDownloadBanner) 및 QR Drawer(DesktopDownloadQRDrawer) 분리
  - QR코드 Drawer 별도 컴포넌트로 분리 및 FocusBox SVG 추가.
  - 퀴즈 생성 버튼(CreateQuizButton) 분리 및 UX 개선

- 데이터 페칭, 페이지네이션 로직 개선
  - useQuery의 useInfiniteQuery를 이용해 구현
