### PR TITLE
feat: 도서관 페이지 검색 로직 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "firebase": "^11.6.0",
     "framer-motion": "^12.5.0",
     "html2pdf.js": "^0.10.3",
+    "immer": "^10.1.1",
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.477.0",
     "mammoth": "^1.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       html2pdf.js:
         specifier: ^0.10.3
         version: 0.10.3
+      immer:
+        specifier: ^10.1.1
+        version: 10.1.1
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
@@ -193,7 +196,7 @@ importers:
         version: 3.24.2
       zustand:
         specifier: ^5.0.3
-        version: 5.0.3(@types/react@19.1.0)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
+        version: 5.0.3(@types/react@19.1.0)(immer@10.1.1)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^3.2.5
@@ -4086,6 +4089,9 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
+  immer@10.1.1:
+    resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -5488,6 +5494,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -10335,6 +10342,8 @@ snapshots:
 
   immediate@3.0.6: {}
 
+  immer@10.1.1: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -12731,9 +12740,10 @@ snapshots:
 
   zod@3.24.2: {}
 
-  zustand@5.0.3(@types/react@19.1.0)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
+  zustand@5.0.3(@types/react@19.1.0)(immer@10.1.1)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
     optionalDependencies:
       '@types/react': 19.1.0
+      immer: 10.1.1
       react: 19.1.0
       use-sync-external-store: 1.5.0(react@19.1.0)
 

--- a/src/app/app-router.tsx
+++ b/src/app/app-router.tsx
@@ -27,7 +27,7 @@ import HomePage from '@/pages/home-page'
 import { InstallGuidePage } from '@/pages/install-guide-page'
 import InviteLoginPage from '@/pages/invite/invite-login-page'
 import InvitePage from '@/pages/invite/invite-page'
-import { LibraryPage, LibrarySearchPage, NoteEditPage, NoteQuizPage } from '@/pages/library'
+import { LibraryPage, NoteEditPage, NoteQuizPage } from '@/pages/library'
 import { NoteCreatePage } from '@/pages/note-create'
 import { ProgressQuizPage } from '@/pages/progress-quiz-page'
 import QuizDetailEditPage from '@/pages/quiz-detail/quiz-detail-edit-page'
@@ -65,7 +65,6 @@ export const AppRouter = () => {
                 {/* Library */}
                 <Route path={RoutePath.library}>
                   <Route index element={<LibraryPage />} />
-                  <Route path={RoutePath.librarySearch} element={<LibrarySearchPage />} />
                   <Route path={RoutePath.libraryNoteQuiz} element={<NoteQuizPage />} />
                   <Route path={RoutePath.libraryNoteEdit} element={<NoteEditPage />} />
                 </Route>

--- a/src/entities/document/api/index.ts
+++ b/src/entities/document/api/index.ts
@@ -195,6 +195,7 @@ export interface SearchDocumentsDto {
   emoji: string
   content: string
   isPublic: boolean
+  isBookmarked: boolean
   tryCount: number
   bookmarkCount: number
   totalQuizCount: number

--- a/src/features/note/store/use-library-search-store.ts
+++ b/src/features/note/store/use-library-search-store.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+
+interface State {
+  keyword: string
+}
+
+interface Actions {
+  setKeyword: (keyword: string) => void
+  clearKeyword: () => void
+}
+
+type Store = State & Actions
+
+const useLibrarySearchStore = create<Store>()(
+  immer<Store>((set) => ({
+    keyword: '',
+
+    setKeyword: (keyword: string) =>
+      set((state) => {
+        state.keyword = keyword
+      }),
+    clearKeyword: () =>
+      set((state) => {
+        state.keyword = ''
+      }),
+  })),
+)
+
+export const useLibrarySearchState = () => {
+  const keyword = useLibrarySearchStore((state) => state.keyword)
+
+  return { keyword }
+}
+
+export const useLibrarySearchKeyword = () => useLibrarySearchStore((state) => state.keyword)
+
+export const useLibrarySearchActions = () => {
+  const setKeyword = useLibrarySearchStore((state) => state.setKeyword)
+  const clearKeyword = useLibrarySearchStore((state) => state.clearKeyword)
+
+  return { setKeyword, clearKeyword }
+}

--- a/src/features/note/ui/my-notes-content/index.tsx
+++ b/src/features/note/ui/my-notes-content/index.tsx
@@ -3,10 +3,10 @@ import { useEffect, useMemo, useState } from 'react'
 import { Tabs, TabsList, TabsTrigger } from '@radix-ui/react-tabs'
 import { toast } from 'sonner'
 
-import { extractPlainText } from '@/features/note/lib'
 import EmptyMyNote from '@/features/note/ui/empty-my-note'
+import { MarkdownProcessor, highlightAndTrimText } from '@/features/search/lib'
 
-import { GetAllDocumentsDocumentDto } from '@/entities/document/api'
+import { GetAllDocumentsDocumentDto, SearchDocumentsDto } from '@/entities/document/api'
 import { useDeleteDocument, useUpdateDocumentIsPublic } from '@/entities/document/api/hooks'
 import { useUser } from '@/entities/member/api/hooks'
 
@@ -33,12 +33,13 @@ import { cn } from '@/shared/lib/utils'
 interface Props {
   activeTab: 'MY' | 'BOOKMARK'
   onTabChange: (tab: 'MY' | 'BOOKMARK') => void
-  documents?: GetAllDocumentsDocumentDto[]
+  documents?: GetAllDocumentsDocumentDto[] | SearchDocumentsDto[]
   selectMode: boolean
   checkList: UseCheckListReturn<GetAllDocumentsDocumentDto>
   changeSelectMode: (selectMode: boolean) => void
   isEmptyMyDocuments: boolean
   isLoading: boolean
+  keyword?: string
 }
 
 const MyNotesContent = ({
@@ -50,6 +51,7 @@ const MyNotesContent = ({
   changeSelectMode,
   isEmptyMyDocuments,
   isLoading,
+  keyword,
 }: Props) => {
   type Tab = typeof activeTab
 
@@ -70,6 +72,10 @@ const MyNotesContent = ({
     () => getCheckedList().reduce((acc, cur) => acc + cur.totalQuizCount, 0),
     [getCheckedList()],
   )
+
+  const isSearchDocType = (doc: GetAllDocumentsDocumentDto | SearchDocumentsDto): doc is SearchDocumentsDto => {
+    return (doc as SearchDocumentsDto).isBookmarked !== undefined
+  }
 
   // 공유하기 핸들러
   const handleShare = async (id: number, name: string) => {
@@ -234,8 +240,25 @@ const MyNotesContent = ({
                 />
 
                 <SlidableNoteCard.Content>
-                  <SlidableNoteCard.Header title={document.name} />
-                  <SlidableNoteCard.Preview content={extractPlainText(document.previewContent)} />
+                  <SlidableNoteCard.Header
+                    title={highlightAndTrimText(document.name ?? '', keyword ?? '', 'subtitle-2-bold')}
+                  />
+                  <SlidableNoteCard.Preview
+                    content={
+                      isSearchDocType(document) ? (
+                        <MarkdownProcessor
+                          markdownText={document.content}
+                          keyword={keyword ?? ''}
+                          typo="body-1-regular"
+                          displayCharCount={40}
+                          truncate
+                        />
+                      ) : (
+                        document.previewContent
+                      )
+                    }
+                  />
+
                   <SlidableNoteCard.Detail
                     quizCount={document.totalQuizCount}
                     playedCount={document.tryCount}

--- a/src/features/search/lib/index.tsx
+++ b/src/features/search/lib/index.tsx
@@ -3,6 +3,7 @@ import { JSX } from 'react'
 import { extractPlainText } from '@/features/note/lib'
 
 import { Text, Typo } from '@/shared/components/ui/text'
+import { cn } from '@/shared/lib/utils'
 
 type Quiz = {
   question: string
@@ -29,24 +30,33 @@ export const MarkdownProcessor = ({
   markdownText,
   keyword,
   typo,
+  displayCharCount = 80,
+  truncate,
 }: {
   markdownText: string
   keyword: string
   typo: Typo
+  displayCharCount?: number
+  truncate?: boolean
 }) => {
   const plainText = extractPlainText(markdownText)
-  const highlightedText = highlightAndTrimText(plainText, keyword, typo)
+  const highlightedText = highlightAndTrimText(plainText, keyword, typo, displayCharCount)
 
-  return <div>{highlightedText}</div>
+  return <div className={cn('w-full', truncate && 'truncate')}>{highlightedText}</div>
 }
 
 /**
  * 텍스트에서 키워드를 강조하는 함수
  */
-export function highlightAndTrimText(text: string, keyword: string, typo: Typo): JSX.Element | string {
+export function highlightAndTrimText(
+  text: string,
+  keyword: string,
+  typo: Typo,
+  displayCharCount?: number,
+): JSX.Element | string {
   if (!text) return text
 
-  const totalLength = 80
+  const totalLength = displayCharCount ?? 80
   const regex = new RegExp(`(${keyword})`, 'gi') // RegExp로 정규표현식 생성
   const match = text.match(regex)
 
@@ -58,12 +68,11 @@ export function highlightAndTrimText(text: string, keyword: string, typo: Typo):
 
   // 첫 번째 매칭된 키워드의 위치
   const keywordIndex = text.toLowerCase().indexOf(keyword.toLowerCase())
-  const keywordLength = keyword.length
 
-  // 키워드 기준 앞뒤로 잘라낼 텍스트 길이 계산
-  const surroundingLength = Math.floor((totalLength - keywordLength) / 2)
+  // 키워드의 살짝 앞에서부터 잘라서 표시 (현재 설정 : 5글자 앞에서부터 표시)
+  const prevCharCount = 5
 
-  const start = Math.max(0, keywordIndex - surroundingLength)
+  const start = Math.max(0, keywordIndex - prevCharCount)
   const end = Math.min(text.length, start + totalLength)
 
   const trimmedText = text.slice(start, end)

--- a/src/pages/library/index.ts
+++ b/src/pages/library/index.ts
@@ -1,6 +1,5 @@
 import LibraryPage from './library-page'
-import LibrarySearchPage from './library-search-page'
 import NoteEditPage from './note-edit-page'
 import NoteQuizPage from './note-quiz-page'
 
-export { NoteEditPage, NoteQuizPage, LibrarySearchPage, LibraryPage }
+export { NoteEditPage, NoteQuizPage, LibraryPage }

--- a/src/pages/library/library-page.tsx
+++ b/src/pages/library/library-page.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 import { withHOC } from '@/app/hoc/with-page-config'
 import HeaderOffsetLayout from '@/app/layout/header-offset-layout'
 
 import { useNoteList } from '@/features/note/hooks/use-note-list'
+import { useLibrarySearchActions, useLibrarySearchKeyword } from '@/features/note/store/use-library-search-store'
 import BookmarkedNotesContent from '@/features/note/ui/bookmarked-notes-content'
 import MyNotesContent from '@/features/note/ui/my-notes-content'
 
@@ -38,7 +39,9 @@ const LibraryPage = () => {
   const isEmptyMyDocuments = !myDocuments || myDocuments.length === 0
   const isEmptyBookmarked = !bookmarkedDocuments || bookmarkedDocuments.length === 0
 
-  const [keyword, setKeyword] = useState('')
+  const keyword = useLibrarySearchKeyword()
+  const { setKeyword, clearKeyword } = useLibrarySearchActions()
+
   const debouncedKeyword = useDebounceValue(keyword, 200)
 
   const onChangeKeyword = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -115,6 +118,7 @@ const LibraryPage = () => {
                 <SearchInput
                   value={keyword}
                   onChange={onChangeKeyword}
+                  clearKeyword={clearKeyword}
                   placeholder="퀴즈 제목, 내용 검색"
                   className="bg-base-3 placeholder:text-caption"
                 />

--- a/src/pages/library/library-page.tsx
+++ b/src/pages/library/library-page.tsx
@@ -1,3 +1,5 @@
+import { useMemo, useState } from 'react'
+
 import { withHOC } from '@/app/hoc/with-page-config'
 import HeaderOffsetLayout from '@/app/layout/header-offset-layout'
 
@@ -5,12 +7,15 @@ import { useNoteList } from '@/features/note/hooks/use-note-list'
 import BookmarkedNotesContent from '@/features/note/ui/bookmarked-notes-content'
 import MyNotesContent from '@/features/note/ui/my-notes-content'
 
+import { useSearchDocument } from '@/entities/document/api/hooks'
+
 import { IcAdd, IcBack, IcSearch } from '@/shared/assets/icon'
 import { Header } from '@/shared/components/header'
-import { Text } from '@/shared/components/ui/text'
+import { SearchInput } from '@/shared/components/ui/search-input'
 import { TextButton } from '@/shared/components/ui/text-button'
 import { useAmplitude } from '@/shared/hooks/use-amplitude-context'
-import { Link, useRouter } from '@/shared/lib/router'
+import { useDebounceValue } from '@/shared/hooks/use-debounce-value'
+import { useRouter } from '@/shared/lib/router'
 
 const LibraryPage = () => {
   const { trackEvent } = useAmplitude()
@@ -25,13 +30,40 @@ const LibraryPage = () => {
 
     myDocsCheckList,
 
-    isLoading,
+    isLoading: isLoadingMyDocs,
     myDocuments,
     bookmarkedDocuments,
   } = useNoteList()
 
   const isEmptyMyDocuments = !myDocuments || myDocuments.length === 0
   const isEmptyBookmarked = !bookmarkedDocuments || bookmarkedDocuments.length === 0
+
+  const [keyword, setKeyword] = useState('')
+  const debouncedKeyword = useDebounceValue(keyword, 200)
+
+  const onChangeKeyword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setKeyword(e.target.value)
+  }
+
+  const { data: searchResultsData, isFetching: isFetchingSearchDocs } = useSearchDocument(
+    { keyword: debouncedKeyword },
+    {
+      enabled: !!debouncedKeyword,
+    },
+  )
+  const searchResultsMyDocs = useMemo(
+    () => searchResultsData?.documents.filter((doc) => !doc.isBookmarked) ?? [],
+    [searchResultsData],
+  )
+  const searchResultsBookmarks = useMemo(
+    () => searchResultsData?.documents.filter((doc) => doc.isBookmarked) ?? [],
+    [searchResultsData],
+  )
+
+  const myDocumentResults = keyword ? searchResultsMyDocs : myDocuments
+  const bookmarkedDocumentResults = keyword ? searchResultsBookmarks : bookmarkedDocuments
+
+  const isLoading = isLoadingMyDocs || isFetchingSearchDocs
 
   type Tab = typeof activeTab
 
@@ -78,15 +110,15 @@ const LibraryPage = () => {
           }
           content={
             <div className="w-[calc(100%-40px)] px-[8px]">
-              <Link
-                to={'/library/search'}
-                className="h-[40px] flex-1 bg-base-3 py-[8px] px-[10px] flex items-center gap-[4px] rounded-full"
-              >
-                <IcSearch className="size-[20px] text-icon-secondary" />
-                <Text typo="subtitle-2-medium" color="caption">
-                  퀴즈 제목, 내용 검색
-                </Text>
-              </Link>
+              <div className="relative">
+                <IcSearch className="absolute left-[10px] top-[50%] -translate-y-[50%] size-[20px] text-icon-secondary" />
+                <SearchInput
+                  value={keyword}
+                  onChange={onChangeKeyword}
+                  placeholder="퀴즈 제목, 내용 검색"
+                  className="bg-base-3 placeholder:text-caption"
+                />
+              </div>
             </div>
           }
         />
@@ -100,10 +132,11 @@ const LibraryPage = () => {
             onTabChange={handleTabChange}
             isLoading={isLoading}
             isEmptyMyDocuments={isEmptyMyDocuments}
-            documents={myDocuments}
+            documents={myDocumentResults}
             selectMode={selectMode}
             changeSelectMode={changeSelectMode}
             checkList={myDocsCheckList}
+            keyword={debouncedKeyword}
           />
         )}
 
@@ -113,7 +146,8 @@ const LibraryPage = () => {
             onTabChange={handleTabChange}
             isLoading={isLoading}
             isEmptyBookmarked={isEmptyBookmarked}
-            documents={bookmarkedDocuments}
+            documents={bookmarkedDocumentResults}
+            keyword={debouncedKeyword}
           />
         )}
       </HeaderOffsetLayout>

--- a/src/pages/library/library-search-page.tsx
+++ b/src/pages/library/library-search-page.tsx
@@ -1,193 +1,198 @@
-import { withHOC } from '@/app/hoc/with-page-config'
-import HeaderOffsetLayout from '@/app/layout/header-offset-layout'
+/**
+ * legacy code
+ * 현재는 사용되지 않는 페이지입니다.
+ */
 
-import { MarkdownProcessor, formatQAText, highlightAndTrimText } from '@/features/search/lib'
-import { useSearch } from '@/features/search/model/use-search'
+// import { withHOC } from '@/app/hoc/with-page-config'
+// import HeaderOffsetLayout from '@/app/layout/header-offset-layout'
 
-import { SearchBookmarkDocumentsDto, SearchDocumentsDto } from '@/entities/document/api'
-import { useSearchDocument } from '@/entities/document/api/hooks'
+// import { MarkdownProcessor, formatQAText, highlightAndTrimText } from '@/features/search/lib'
+// import { useSearch } from '@/features/search/model/use-search'
 
-import { BackButton } from '@/shared/components/buttons/back-button'
-import { Header } from '@/shared/components/header'
-import SearchQuizItem from '@/shared/components/items/search-quiz-item'
-import Loading from '@/shared/components/ui/loading'
-import { SearchInput } from '@/shared/components/ui/search-input'
-import { Tabs, TabsList, TabsTrigger } from '@/shared/components/ui/tabs'
-import { Text } from '@/shared/components/ui/text'
-import { Link, useQueryParam } from '@/shared/lib/router'
-import { StorageKey } from '@/shared/lib/storage'
+// import { SearchBookmarkDocumentsDto, SearchDocumentsDto } from '@/entities/document/api'
+// import { useSearchDocument } from '@/entities/document/api/hooks'
 
-type Tab = 'MY' | 'BOOKMARK'
+// import { BackButton } from '@/shared/components/buttons/back-button'
+// import { Header } from '@/shared/components/header'
+// import SearchQuizItem from '@/shared/components/items/search-quiz-item'
+// import Loading from '@/shared/components/ui/loading'
+// import { SearchInput } from '@/shared/components/ui/search-input'
+// import { Tabs, TabsList, TabsTrigger } from '@/shared/components/ui/tabs'
+// import { Text } from '@/shared/components/ui/text'
+// import { Link, useQueryParam } from '@/shared/lib/router'
+// import { StorageKey } from '@/shared/lib/storage'
 
-const LibrarySearchPage = () => {
-  const [activeTab, setTab] = useQueryParam('/library/search', 'tab')
-  const {
-    inputValue,
-    setInputValue,
-    queryKeyword,
-    showRecentKeywords,
-    setShowRecentKeywords,
-    searchInputRef,
-    handleClearKeyword,
-    onSearchSubmit,
-    RecentSearchKeywords,
-  } = useSearch(StorageKey.libraryRecentSearchKeyword)
+// type Tab = 'MY' | 'BOOKMARK'
 
-  // 쿼리를 사용하여 queryKeyword 변경 시 자동으로 검색 실행
-  const { data: searchResultsData, isFetching } = useSearchDocument(
-    { keyword: queryKeyword },
-    {
-      enabled: !!queryKeyword && !showRecentKeywords,
-    },
-  )
-  const searchResultsMyDocs = searchResultsData?.documents ?? []
-  const searchResultsBookmarks = searchResultsData?.bookmarkedDocuments ?? []
+// const LibrarySearchPage = () => {
+//   const [activeTab, setTab] = useQueryParam('/library/search', 'tab')
+//   const {
+//     inputValue,
+//     setInputValue,
+//     queryKeyword,
+//     showRecentKeywords,
+//     setShowRecentKeywords,
+//     searchInputRef,
+//     handleClearKeyword,
+//     onSearchSubmit,
+//     RecentSearchKeywords,
+//   } = useSearch(StorageKey.libraryRecentSearchKeyword)
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    if (!inputValue.trim()) return
+//   // 쿼리를 사용하여 queryKeyword 변경 시 자동으로 검색 실행
+//   const { data: searchResultsData, isFetching } = useSearchDocument(
+//     { keyword: queryKeyword },
+//     {
+//       enabled: !!queryKeyword && !showRecentKeywords,
+//     },
+//   )
+//   const searchResultsMyDocs = searchResultsData?.documents ?? []
+//   const searchResultsBookmarks = searchResultsData?.bookmarkedDocuments ?? []
 
-    // onSearchSubmit 호출 시 URL이 업데이트되고 queryKeyword가 변경됨
-    // 이에 따라 자동으로 useSearchDocumentsQuery가 실행됨
-    onSearchSubmit()
-  }
+//   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+//     e.preventDefault()
+//     if (!inputValue.trim()) return
 
-  const onChangeKeyword = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value)
-  }
+//     // onSearchSubmit 호출 시 URL이 업데이트되고 queryKeyword가 변경됨
+//     // 이에 따라 자동으로 useSearchDocumentsQuery가 실행됨
+//     onSearchSubmit()
+//   }
 
-  // 탭에 따라 결과 컨텐츠 설정
-  const tabConfig: Record<Tab, { documents: SearchDocumentsDto[] | SearchBookmarkDocumentsDto[] }> = {
-    MY: { documents: searchResultsMyDocs },
-    BOOKMARK: { documents: searchResultsBookmarks },
-  }
+//   const onChangeKeyword = (e: React.ChangeEvent<HTMLInputElement>) => {
+//     setInputValue(e.target.value)
+//   }
 
-  const activeDocuments = tabConfig[activeTab].documents
-  const hasResults = activeDocuments.length > 0
+//   // 탭에 따라 결과 컨텐츠 설정
+//   const tabConfig: Record<Tab, { documents: SearchDocumentsDto[] | SearchBookmarkDocumentsDto[] }> = {
+//     MY: { documents: searchResultsMyDocs },
+//     BOOKMARK: { documents: searchResultsBookmarks },
+//   }
 
-  return (
-    <div className="h-screen bg-base-1 flex flex-col">
-      <Header
-        left={<BackButton className="mr-1" />}
-        content={
-          <>
-            <form onSubmit={handleSubmit} tabIndex={-1} className="relative grow">
-              <SearchInput
-                autoFocus
-                ref={searchInputRef}
-                onFocus={() => setShowRecentKeywords(true)}
-                value={inputValue}
-                onChange={onChangeKeyword}
-                clearKeyword={handleClearKeyword}
-                placeholder="퀴즈 제목, 내용 검색"
-              />
-            </form>
+//   const activeDocuments = tabConfig[activeTab].documents
+//   const hasResults = activeDocuments.length > 0
 
-            {/* input 클릭 시 나타날 최근 검색어 : 외부 영역 클릭 시 닫힘 */}
-            {showRecentKeywords && <RecentSearchKeywords />}
-          </>
-        }
-      />
+//   return (
+//     <div className="h-screen bg-base-1 flex flex-col">
+//       <Header
+//         left={<BackButton className="mr-1" />}
+//         content={
+//           <>
+//             <form onSubmit={handleSubmit} tabIndex={-1} className="relative grow">
+//               <SearchInput
+//                 autoFocus
+//                 ref={searchInputRef}
+//                 onFocus={() => setShowRecentKeywords(true)}
+//                 value={inputValue}
+//                 onChange={onChangeKeyword}
+//                 clearKeyword={handleClearKeyword}
+//                 placeholder="퀴즈 제목, 내용 검색"
+//               />
+//             </form>
 
-      <HeaderOffsetLayout className="relative h-full">
-        {isFetching && <Loading center />}
+//             {/* input 클릭 시 나타날 최근 검색어 : 외부 영역 클릭 시 닫힘 */}
+//             {showRecentKeywords && <RecentSearchKeywords />}
+//           </>
+//         }
+//       />
 
-        {!isFetching && !showRecentKeywords && queryKeyword && (
-          <>
-            <Tabs value={activeTab} onValueChange={(tab) => setTab(tab as Tab)}>
-              <TabsList className="bg-surface-1 rounded-none h-fit p-0">
-                <TabsTrigger
-                  className="typo-button-2 bg-surface-1 border-b border-divider data-[state=active]:border-b-2 data-[state=active]:border-black text-sub data-[state=active]:text-primary h-[48px] w-1/2 rounded-none"
-                  value={'MY' as Tab}
-                >
-                  내 퀴즈
-                </TabsTrigger>
-                <TabsTrigger
-                  className="typo-button-2 bg-surface-1 border-b border-divider data-[state=active]:border-b-2 data-[state=active]:border-black text-sub data-[state=active]:text-primary h-[48px] w-1/2 rounded-none"
-                  value={'BOOKMARK' as Tab}
-                >
-                  북마크
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
-            <TabContent tab={activeTab} documents={activeDocuments} keyword={queryKeyword} hasResults={hasResults} />
-          </>
-        )}
-      </HeaderOffsetLayout>
-    </div>
-  )
-}
+//       <HeaderOffsetLayout className="relative h-full">
+//         {isFetching && <Loading center />}
 
-interface TabContentProps {
-  tab: Tab
-  documents: SearchDocumentsDto[] | SearchBookmarkDocumentsDto[]
-  keyword: string
-  hasResults: boolean
-}
+//         {!isFetching && !showRecentKeywords && queryKeyword && (
+//           <>
+//             <Tabs value={activeTab} onValueChange={(tab) => setTab(tab as Tab)}>
+//               <TabsList className="bg-surface-1 rounded-none h-fit p-0">
+//                 <TabsTrigger
+//                   className="typo-button-2 bg-surface-1 border-b border-divider data-[state=active]:border-b-2 data-[state=active]:border-black text-sub data-[state=active]:text-primary h-[48px] w-1/2 rounded-none"
+//                   value={'MY' as Tab}
+//                 >
+//                   내 퀴즈
+//                 </TabsTrigger>
+//                 <TabsTrigger
+//                   className="typo-button-2 bg-surface-1 border-b border-divider data-[state=active]:border-b-2 data-[state=active]:border-black text-sub data-[state=active]:text-primary h-[48px] w-1/2 rounded-none"
+//                   value={'BOOKMARK' as Tab}
+//                 >
+//                   북마크
+//                 </TabsTrigger>
+//               </TabsList>
+//             </Tabs>
+//             <TabContent tab={activeTab} documents={activeDocuments} keyword={queryKeyword} hasResults={hasResults} />
+//           </>
+//         )}
+//       </HeaderOffsetLayout>
+//     </div>
+//   )
+// }
 
-const TabContent = ({ tab, documents, keyword, hasResults }: TabContentProps) => {
-  if (!hasResults && keyword) {
-    return (
-      <div className="size-full flex-center flex-col gap-[8px] pb-[108px]">
-        <Text typo="subtitle-1-bold">검색 결과가 없어요</Text>
-        <Text typo="body-1-medium" color="sub">
-          다른 키워드를 입력해보세요
-        </Text>
-      </div>
-    )
-  }
+// interface TabContentProps {
+//   tab: Tab
+//   documents: SearchDocumentsDto[] | SearchBookmarkDocumentsDto[]
+//   keyword: string
+//   hasResults: boolean
+// }
 
-  return <LibrarySearchResults tab={tab} documents={documents} keyword={keyword} />
-}
+// const TabContent = ({ tab, documents, keyword, hasResults }: TabContentProps) => {
+//   if (!hasResults && keyword) {
+//     return (
+//       <div className="size-full flex-center flex-col gap-[8px] pb-[108px]">
+//         <Text typo="subtitle-1-bold">검색 결과가 없어요</Text>
+//         <Text typo="body-1-medium" color="sub">
+//           다른 키워드를 입력해보세요
+//         </Text>
+//       </div>
+//     )
+//   }
 
-interface LibrarySearchResultsProps {
-  tab: Tab
-  documents: SearchDocumentsDto[] | SearchBookmarkDocumentsDto[]
-  keyword: string
-}
+//   return <LibrarySearchResults tab={tab} documents={documents} keyword={keyword} />
+// }
 
-/** 내 문서에서 검색 결과가 있을 때 결과들을 보여주는 컴포넌트 */
-const LibrarySearchResults = ({ tab, documents, keyword }: LibrarySearchResultsProps) => {
-  function isSearchDocumentsDto(item: SearchDocumentsDto | SearchBookmarkDocumentsDto): item is SearchDocumentsDto {
-    return 'content' in item && typeof item.content === 'string'
-  }
+// interface LibrarySearchResultsProps {
+//   tab: Tab
+//   documents: SearchDocumentsDto[] | SearchBookmarkDocumentsDto[]
+//   keyword: string
+// }
 
-  return (
-    <div className="h-[calc(100%-48px)] flex flex-col px-[16px] pt-[16px] overflow-y-auto">
-      <Text typo="body-1-medium">
-        결과 <span className="text-accent">{documents.length}</span>
-      </Text>
+// /** 내 문서에서 검색 결과가 있을 때 결과들을 보여주는 컴포넌트 */
+// const LibrarySearchResults = ({ tab, documents, keyword }: LibrarySearchResultsProps) => {
+//   function isSearchDocumentsDto(item: SearchDocumentsDto | SearchBookmarkDocumentsDto): item is SearchDocumentsDto {
+//     return 'content' in item && typeof item.content === 'string'
+//   }
 
-      <div className="h-fit flex flex-col pb-[16px]">
-        {documents.map((searchItem, idx) => {
-          return (
-            <Link
-              key={searchItem.id}
-              to={tab === 'MY' ? '/quiz-detail/:noteId' : '/quiz-detail/:noteId'}
-              params={[String(searchItem.id)]}
-            >
-              <SearchQuizItem
-                documentTitle={highlightAndTrimText(searchItem.name ?? '', keyword ?? '', 'subtitle-2-bold')}
-                documentEmoji={searchItem.emoji}
-                matchingSentence={
-                  isSearchDocumentsDto(searchItem) && searchItem.content.includes(keyword) ? (
-                    <MarkdownProcessor markdownText={searchItem.content} keyword={keyword ?? ''} typo="body-1-bold" />
-                  ) : (
-                    highlightAndTrimText(formatQAText(searchItem.quizzes), keyword ?? '', 'body-1-bold')
-                  )
-                }
-                quizCount={searchItem.totalQuizCount}
-                isPublic={isSearchDocumentsDto(searchItem) ? searchItem.isPublic : true}
-                playedCount={searchItem.tryCount}
-                bookmarkCount={searchItem.bookmarkCount}
-                lastItem={idx === documents.length - 1}
-              />
-            </Link>
-          )
-        })}
-      </div>
-    </div>
-  )
-}
+//   return (
+//     <div className="h-[calc(100%-48px)] flex flex-col px-[16px] pt-[16px] overflow-y-auto">
+//       <Text typo="body-1-medium">
+//         결과 <span className="text-accent">{documents.length}</span>
+//       </Text>
 
-export default withHOC(LibrarySearchPage, {})
+//       <div className="h-fit flex flex-col pb-[16px]">
+//         {documents.map((searchItem, idx) => {
+//           return (
+//             <Link
+//               key={searchItem.id}
+//               to={tab === 'MY' ? '/quiz-detail/:noteId' : '/quiz-detail/:noteId'}
+//               params={[String(searchItem.id)]}
+//             >
+//               <SearchQuizItem
+//                 documentTitle={highlightAndTrimText(searchItem.name ?? '', keyword ?? '', 'subtitle-2-bold')}
+//                 documentEmoji={searchItem.emoji}
+//                 matchingSentence={
+//                   isSearchDocumentsDto(searchItem) && searchItem.content.includes(keyword) ? (
+//                     <MarkdownProcessor markdownText={searchItem.content} keyword={keyword ?? ''} typo="body-1-bold" />
+//                   ) : (
+//                     highlightAndTrimText(formatQAText(searchItem.quizzes), keyword ?? '', 'body-1-bold')
+//                   )
+//                 }
+//                 quizCount={searchItem.totalQuizCount}
+//                 isPublic={isSearchDocumentsDto(searchItem) ? searchItem.isPublic : true}
+//                 playedCount={searchItem.tryCount}
+//                 bookmarkCount={searchItem.bookmarkCount}
+//                 lastItem={idx === documents.length - 1}
+//               />
+//             </Link>
+//           )
+//         })}
+//       </div>
+//     </div>
+//   )
+// }
+
+// export default withHOC(LibrarySearchPage, {})

--- a/src/shared/components/cards/bookmark-horizontal-card/index.tsx
+++ b/src/shared/components/cards/bookmark-horizontal-card/index.tsx
@@ -41,7 +41,7 @@ const BookmarkHorizontalCardContent = ({ children }: { children: React.ReactNode
   )
 }
 
-const BookmarkHorizontalCardHeader = ({ title, tag }: { title: string; tag?: React.ReactNode }) => {
+const BookmarkHorizontalCardHeader = ({ title, tag }: { title: React.ReactNode; tag?: React.ReactNode }) => {
   return (
     <div className="relative mb-[2px] flex items-center gap-[8px]">
       <Text as="h4" typo="subtitle-2-bold" className="w-fit max-w-[calc(100%-100px)] overflow-x-hidden truncate">
@@ -53,7 +53,7 @@ const BookmarkHorizontalCardHeader = ({ title, tag }: { title: string; tag?: Rea
   )
 }
 
-const BookmarkHorizontalCardPreview = ({ content }: { content: string }) => {
+const BookmarkHorizontalCardPreview = ({ content }: { content: React.ReactNode }) => {
   return (
     <Text typo="body-1-regular" color="sub" className="w-[calc(100%-40px)] truncate text-nowrap break-all">
       {content}

--- a/src/shared/components/cards/slidable-note-card/index.tsx
+++ b/src/shared/components/cards/slidable-note-card/index.tsx
@@ -169,7 +169,7 @@ const SlidableNoteCardContent = ({ children }: { children: React.ReactNode }) =>
   return <div className="ml-[12px] flex w-[calc(100%-55px)] flex-col">{children}</div>
 }
 
-const SlidableNoteCardHeader = ({ title, tag }: { title: string; tag?: React.ReactNode }) => {
+const SlidableNoteCardHeader = ({ title, tag }: { title: React.ReactNode; tag?: React.ReactNode }) => {
   return (
     <div className="mb-[2px] flex items-center gap-[8px]">
       <Text as="h4" typo="subtitle-2-bold" className="w-fit max-w-[calc(100%-100px)] overflow-x-hidden truncate">
@@ -181,7 +181,7 @@ const SlidableNoteCardHeader = ({ title, tag }: { title: string; tag?: React.Rea
   )
 }
 
-const SlidableNoteCardPreview = ({ content }: { content: string }) => {
+const SlidableNoteCardPreview = ({ content }: { content: React.ReactNode }) => {
   return (
     <Text typo="body-1-regular" color="sub" className="w-[calc(100%-40px)] truncate text-nowrap break-all">
       {content}

--- a/src/shared/components/ui/search-input/index.tsx
+++ b/src/shared/components/ui/search-input/index.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useEffect, useRef, useState } from 'react'
 
 import { IcClear, IcSearch } from '@/shared/assets/icon'
+import { cn } from '@/shared/lib/utils'
 
 import { Input } from '../input'
 
@@ -9,7 +10,7 @@ interface SearchInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 }
 
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
-  ({ value, onChange, clearKeyword, ...props }: SearchInputProps, ref) => {
+  ({ value, onChange, clearKeyword, className, ...props }: SearchInputProps, ref) => {
     const [internalValue, setValue] = useState(value)
     const inputRef = useRef<HTMLInputElement>(null)
 
@@ -35,12 +36,12 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
     }
 
     return (
-      <div className="bg-base-2 flex items-center rounded-full overflow-hidden">
+      <div className={cn('bg-base-2 flex items-center rounded-full overflow-hidden', className)}>
         <IcSearch className="size-[20px] shrink-0 ml-[10px] text-icon-secondary" />
         <Input
           ref={mergedRef}
           value={internalValue}
-          className="h-[40px] border-none bg-base-2 pl-1 focus:border-none placeholder:text-caption"
+          className={cn('h-[40px] border-none bg-base-2 pl-1 focus:border-none placeholder:text-caption', className)}
           placeholder="검색어를 입력해주세요"
           right={
             internalValue && (

--- a/src/shared/hooks/use-debounce-value.ts
+++ b/src/shared/hooks/use-debounce-value.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * useDebounceValue
+ * @param value 디바운스할 값
+ * @param delay 디바운스 지연 시간(ms)
+ * @returns delay 이후 확정된 값
+ */
+export function useDebounceValue<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    // 값이 변경되면 기존 타이머 취소
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/src/shared/lib/router/config/index.ts
+++ b/src/shared/lib/router/config/index.ts
@@ -58,12 +58,6 @@ export const RouteConfig = {
       bookmarkedSortOption: null as BookmarkedSortOption | null,
     },
   },
-  librarySearch: {
-    pathname: '/library/search',
-    search: {
-      tab: 'MY' as 'MY' | 'BOOKMARK',
-    },
-  },
   libraryNoteDetailList: {
     pathname: '/library/list/:noteId',
     search: {


### PR DESCRIPTION
## 주요 내용
- /library/search 에서 동작하던 검색 기능을 도서관 메인 페이지로 이동

## 상세
- 기존 documents 목록 데이터 스키마와 북마크 목록 데이터 스키마와 검색 결과 데이터 스키마 수정
- 해당 데이터 스키마를 판단해 각각 적절한 데이터를 추출, 컴포넌트에 데이터 전달
- 검색 시 키워드와 일치하는 텍스트에 강조표시가 되도록 수정
- 잦은 키워드 변경이 예정되어 있으므로 url search params를 변경하는 방식이 아닌 상태로 키워드 관리
- 검색 키워드는 페이지 이동 시 유지될 수 있도록 전역 상태로 관리
- 효율적인 api 호출을 위해 디바운스 적용. (마지막 키워드 변경 후 200ms 후에 api 호출)